### PR TITLE
Turn message in test_hello_world.py into bytes

### DIFF
--- a/test_hello_world.py
+++ b/test_hello_world.py
@@ -14,7 +14,7 @@ class TestHelloWorld(unittest.TestCase):
     def test_message(self):
         response = self.app.get('/')
         message = hello_world.wrap_html('Hello PyLadies Chicago!')
-        self.assertEqual(response.data, message)
+        self.assertEqual(response.data, bytes(message, 'utf-8'))  # turn message into bytes for proper comparison
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
`response.data` is in byte. Direct comparing `response.data` to `message`, which is a string, leads to failure in the second test. Turning `message` into bytes resolves this issue and the second test succeeds (only tested in Python3).